### PR TITLE
Fix "Permission denied" error when trying to install without author key

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "should": "0.6.0"
     },
     "dependencies": {
-        "v8-profiler": "git+ssh://git@github.com:c4milo/v8-profiler.git#master",
+        "v8-profiler": "git://github.com/c4milo/v8-profiler.git#master",
         "ws": "0.4.11"
     },
     "main": "webkit-devtools-agent"


### PR DESCRIPTION
When i trying to install module from npm i got Permission denied error because i haven't key to c4milo / v8-profiler. I was changed this dependency to read-only source.
