### PR TITLE
Use wildcard binding address as better default IP

### DIFF
--- a/webkit-devtools-agent.js
+++ b/webkit-devtools-agent.js
@@ -9,7 +9,7 @@ var DevToolsAgentProxy = module.exports = function() {
     this.frontend = null;
     this.debuggerAgent = null;
     this.port = process.env.DEBUG_PORT || 9999;
-    this.host = process.env.DEBUG_HOST || '127.0.0.1';
+    this.host = process.env.DEBUG_HOST || '0.0.0.0';
 };
 
 (function() {


### PR DESCRIPTION
Binding to 0.0.0.0 binds to all network interfaces so that you
don't actually have to specify DEBUG_HOST to be your ip address.

This will prevent new users from having issues like: https://github.com/c4milo/node-webkit-agent/issues/6
