### PR TITLE
Fix erronious stack dump on error when debug agent was not used.

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,7 +210,9 @@ if (!module.parent) {
         if (e) {
             console.error(e.stack);
         }
-        nodeAgent.stop();
+        if (nodeAgent.server) {
+		  nodeAgent.stop();
+		}
     });
 });
 


### PR DESCRIPTION
At the very end of the code it wasn't checking to see if the webkit agent server was started, but it calls stop.   This causes another fault.

This basically adds the check to see if it is running before it trys to "stop" it.
