### PR TITLE
Bundle modified v8-profiler

### DIFF
--- a/lib/v8-profiler/.gitignore
+++ b/lib/v8-profiler/.gitignore
@@ -1,0 +1,6 @@
+/profiler.node
+build/*
+.lock-wscript
+*.swp
+*.swo
+.DS_Store

--- a/lib/v8-profiler/Makefile
+++ b/lib/v8-profiler/Makefile
@@ -1,0 +1,4 @@
+build:
+	node-waf distclean configure build
+
+.PHONY: build

--- a/lib/v8-profiler/binding.gyp
+++ b/lib/v8-profiler/binding.gyp
@@ -1,0 +1,15 @@
+{
+  'targets': [
+    {
+      'target_name': 'profiler',
+      'sources': [
+        'cpu_profiler.cc',
+        'heap_profiler.cc',
+        'profile.cc',
+        'profile_node.cc',
+        'profiler.cc',
+        'snapshot.cc',
+      ],
+    }
+  ]
+}

--- a/lib/v8-profiler/cpu_profiler.cc
+++ b/lib/v8-profiler/cpu_profiler.cc
@@ -1,0 +1,75 @@
+#include "cpu_profiler.h"
+#include "profile.h"
+
+namespace nodex {
+    Persistent<ObjectTemplate> CpuProfiler::cpu_profiler_template_;
+
+    void CpuProfiler::Initialize(Handle<Object> target) {
+        HandleScope scope;
+
+        cpu_profiler_template_ = Persistent<ObjectTemplate>::New(ObjectTemplate::New());
+        cpu_profiler_template_->SetInternalFieldCount(1);
+
+        Local<Object> cpuProfilerObj = cpu_profiler_template_->NewInstance();
+
+        NODE_SET_METHOD(cpuProfilerObj, "getProfilesCount", CpuProfiler::GetProfilesCount);
+        NODE_SET_METHOD(cpuProfilerObj, "getProfile", CpuProfiler::GetProfile);
+        NODE_SET_METHOD(cpuProfilerObj, "findProfile", CpuProfiler::FindProfile);
+        NODE_SET_METHOD(cpuProfilerObj, "startProfiling", CpuProfiler::StartProfiling);
+        NODE_SET_METHOD(cpuProfilerObj, "stopProfiling", CpuProfiler::StopProfiling);
+        NODE_SET_METHOD(cpuProfilerObj, "deleteAllProfiles", CpuProfiler::DeleteAllProfiles);
+
+        target->Set(String::NewSymbol("cpuProfiler"), cpuProfilerObj);
+    }
+
+    CpuProfiler::CpuProfiler() {}
+    CpuProfiler::~CpuProfiler() {}
+
+    Handle<Value> CpuProfiler::GetProfilesCount(const Arguments& args) {
+        HandleScope scope;
+        return scope.Close(Integer::New(v8::CpuProfiler::GetProfilesCount()));
+    }
+
+    Handle<Value> CpuProfiler::GetProfile(const Arguments& args) {
+        HandleScope scope;
+        if (args.Length() < 1) {
+            return ThrowException(Exception::Error(String::New("No index specified")));
+        } else if (!args[0]->IsInt32()) {
+            return ThrowException(Exception::TypeError(String::New("Argument must be an integer")));
+        }
+        int32_t index = args[0]->Int32Value();
+        const CpuProfile* profile = v8::CpuProfiler::GetProfile(index);
+        return scope.Close(Profile::New(profile));
+    }
+
+    Handle<Value> CpuProfiler::FindProfile(const Arguments& args) {
+        HandleScope scope;
+        if (args.Length() < 1) {
+            return ThrowException(Exception::Error(String::New("No index specified")));
+        } else if (!args[0]->IsInt32()) {
+            return ThrowException(Exception::TypeError(String::New("Argument must be an integer")));
+        }
+        uint32_t uid = args[0]->Uint32Value();
+        const CpuProfile* profile = v8::CpuProfiler::FindProfile(uid);
+        return scope.Close(Profile::New(profile));
+    }
+
+    Handle<Value> CpuProfiler::StartProfiling(const Arguments& args) {
+        HandleScope scope;
+        Local<String> title = args.Length() > 0 ? args[0]->ToString() : String::New("");
+        v8::CpuProfiler::StartProfiling(title);
+        return Undefined();
+    }
+
+    Handle<Value> CpuProfiler::StopProfiling(const Arguments& args) {
+        HandleScope scope;
+        Local<String> title = args.Length() > 0 ? args[0]->ToString() : String::New("");
+        const CpuProfile* profile = v8::CpuProfiler::StopProfiling(title);
+        return scope.Close(Profile::New(profile));
+    }
+
+    Handle<Value> CpuProfiler::DeleteAllProfiles(const Arguments& args) {
+        v8::CpuProfiler::DeleteAllProfiles();
+        return Undefined();
+    }
+} //namespace nodex

--- a/lib/v8-profiler/cpu_profiler.h
+++ b/lib/v8-profiler/cpu_profiler.h
@@ -1,0 +1,31 @@
+#ifndef NODE_CPU_PROFILER_
+#define NODE_CPU_PROFILER_
+
+#include <v8-profiler.h>
+#include <node.h>
+
+using namespace v8;
+using namespace node;
+
+namespace nodex {
+    class CpuProfiler {
+        public:
+            static void Initialize(Handle<Object> target);
+
+            CpuProfiler();
+            virtual ~CpuProfiler();
+
+        protected:
+            static Handle<Value> GetProfilesCount(const Arguments& args);
+            static Handle<Value> GetProfile(const Arguments& args);
+            static Handle<Value> FindProfile(const Arguments& args);
+            static Handle<Value> StartProfiling(const Arguments& args);
+            static Handle<Value> StopProfiling(const Arguments& args);
+            static Handle<Value> DeleteAllProfiles(const Arguments& args);
+
+        private:
+            static Persistent<ObjectTemplate> cpu_profiler_template_;
+    };
+} //namespace nodex
+
+#endif  // NODE_CPU_PROFILER_H

--- a/lib/v8-profiler/heap_profiler.cc
+++ b/lib/v8-profiler/heap_profiler.cc
@@ -1,0 +1,129 @@
+#include "heap_profiler.h"
+#include "snapshot.h"
+
+namespace nodex {
+    Persistent<ObjectTemplate> HeapProfiler::heap_profiler_template_;
+
+    class ActivityControlAdapter : public ActivityControl {
+        public:
+            ActivityControlAdapter(Handle<Value> progress)
+                :   reportProgress(Handle<Function>::Cast(progress)),
+                    abort(Local<Value>::New(Boolean::New(false))) {}
+
+            ControlOption ReportProgressValue(int done, int total) {
+                HandleScope scope;
+
+                Local<Value> argv[2] = {
+                    Integer::New(done),
+                    Integer::New(total)
+                };
+
+                TryCatch try_catch;
+
+                abort = reportProgress->Call(Context::GetCurrent()->Global(), 2, argv);
+
+                if (try_catch.HasCaught()) {
+                    FatalException(try_catch);
+                    return kAbort;
+                }
+
+                fprintf(stderr, "here!\n");
+
+                if (abort.IsEmpty() || !abort->IsBoolean()) {
+                    return kContinue;
+                }
+
+                return abort->IsTrue() ? kAbort : kContinue;
+            }
+
+        private:
+            Handle<Function> reportProgress; 
+            Local<Value> abort;
+    };
+
+    void HeapProfiler::Initialize(Handle<Object> target) {
+        HandleScope scope;
+
+        heap_profiler_template_ = Persistent<ObjectTemplate>::New(ObjectTemplate::New());
+        heap_profiler_template_->SetInternalFieldCount(1);
+
+        Local<Object> heapProfilerObj = heap_profiler_template_->NewInstance();
+
+        NODE_SET_METHOD(heapProfilerObj, "takeSnapshot", HeapProfiler::TakeSnapshot);
+        NODE_SET_METHOD(heapProfilerObj, "getSnapshot", HeapProfiler::GetSnapshot);
+        NODE_SET_METHOD(heapProfilerObj, "findSnapshot", HeapProfiler::FindSnapshot);
+        NODE_SET_METHOD(heapProfilerObj, "getSnapshotsCount", HeapProfiler::GetSnapshotsCount);
+        NODE_SET_METHOD(heapProfilerObj, "deleteAllSnapshots", HeapProfiler::DeleteAllSnapshots);
+
+        target->Set(String::NewSymbol("heapProfiler"), heapProfilerObj);
+    }
+
+    HeapProfiler::HeapProfiler() {}
+    HeapProfiler::~HeapProfiler() {}
+
+    Handle<Value> HeapProfiler::GetSnapshotsCount(const Arguments& args) {
+        HandleScope scope;
+        return scope.Close(Integer::New(v8::HeapProfiler::GetSnapshotsCount()));
+    }
+
+    Handle<Value> HeapProfiler::GetSnapshot(const Arguments& args) {
+        HandleScope scope;
+        if (args.Length() < 1) {
+            return ThrowException(Exception::Error(String::New("No index specified")));
+        } else if (!args[0]->IsInt32()) {
+            return ThrowException(Exception::TypeError(String::New("Argument must be an integer")));
+        }
+        int32_t index = args[0]->Int32Value();
+        const v8::HeapSnapshot* snapshot = v8::HeapProfiler::GetSnapshot(index);
+
+        return scope.Close(Snapshot::New(snapshot));
+    }
+
+    Handle<Value> HeapProfiler::FindSnapshot(const Arguments& args) {
+        HandleScope scope;
+        if (args.Length() < 1) {
+            return ThrowException(Exception::Error(String::New("No uid specified")));
+        }
+
+        uint32_t uid = args[0]->Uint32Value();
+        const v8::HeapSnapshot* snapshot = v8::HeapProfiler::FindSnapshot(uid);
+
+        return scope.Close(Snapshot::New(snapshot));
+    }
+
+    Handle<Value> HeapProfiler::TakeSnapshot(const Arguments& args) {
+        HandleScope scope;
+        Local<String> title = String::New("");
+        uint32_t len = args.Length();
+
+        ActivityControlAdapter *control = NULL;
+
+        if (len == 1) {
+            if (args[0]->IsString()) {
+                title = args[0]->ToString();
+            } else if (args[0]->IsFunction()) {
+                //control = new ActivityControlAdapter(args[0]);
+            }
+        }
+
+        if (len == 2) {
+            if (args[0]->IsString()) {
+                title = args[0]->ToString();
+            }
+
+            if (args[1]->IsFunction()) {
+                //control = new ActivityControlAdapter(args[1]);
+            }
+        }
+
+        const v8::HeapSnapshot* snapshot = v8::HeapProfiler::TakeSnapshot(title, HeapSnapshot::kFull, control);
+
+        return scope.Close(Snapshot::New(snapshot));
+    }
+
+    Handle<Value> HeapProfiler::DeleteAllSnapshots(const Arguments& args) {
+        HandleScope scope;
+        v8::HeapProfiler::DeleteAllSnapshots();
+        return Undefined();
+    }
+} //namespace nodex

--- a/lib/v8-profiler/heap_profiler.h
+++ b/lib/v8-profiler/heap_profiler.h
@@ -1,0 +1,30 @@
+#ifndef NODE_HEAP_PROFILER_
+#define NODE_HEAP_PROFILER_
+
+#include <v8-profiler.h>
+#include <node.h>
+
+using namespace v8;
+using namespace node;
+
+namespace nodex {
+    class HeapProfiler {
+        public:
+            static void Initialize(Handle<Object> target);
+
+            HeapProfiler();
+            virtual ~HeapProfiler();
+
+        protected:
+            static Handle<Value> GetSnapshotsCount(const Arguments& args);
+            static Handle<Value> GetSnapshot(const Arguments& args);
+            static Handle<Value> FindSnapshot(const Arguments& args);
+            static Handle<Value> TakeSnapshot(const Arguments& args);
+            static Handle<Value> DeleteAllSnapshots(const Arguments& args);
+
+        private:
+            static Persistent<ObjectTemplate> heap_profiler_template_;
+    };
+} //namespace nodex
+
+#endif  // NODE_HEAP_PROFILER_H

--- a/lib/v8-profiler/package.json
+++ b/lib/v8-profiler/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "v8-profiler",
+  "version": "4.0.0",
+  "description": "node bindings for the v8 profiler",
+  "homepage": "http://github.com/dannycoates/v8-profiler",
+  "author": "Danny Coates <dannycoates@gmail.com>",
+  "keywords": [
+    "profiler",
+    "inspector"
+  ],
+  "engines": {
+    "node": ">=0.6"
+  },
+  "main": "v8-profiler",
+  "scripts": {
+    "postinstall": "ln -sf build/Release/profiler.node profiler.node"
+  }
+}

--- a/lib/v8-profiler/profile.cc
+++ b/lib/v8-profiler/profile.cc
@@ -1,0 +1,78 @@
+#include "profile.h"
+#include "profile_node.h"
+
+using namespace v8;
+
+namespace nodex {
+
+Persistent<ObjectTemplate> Profile::profile_template_;
+
+void Profile::Initialize() {
+  profile_template_ = Persistent<ObjectTemplate>::New(ObjectTemplate::New());
+  profile_template_->SetInternalFieldCount(1);
+  profile_template_->SetAccessor(String::New("title"), Profile::GetTitle);
+  profile_template_->SetAccessor(String::New("uid"), Profile::GetUid);
+  profile_template_->SetAccessor(String::New("topRoot"), Profile::GetTopRoot);
+  profile_template_->SetAccessor(String::New("bottomRoot"), Profile::GetBottomRoot);
+  profile_template_->Set(String::New("delete"), FunctionTemplate::New(Profile::Delete));
+}
+
+Handle<Value> Profile::GetUid(Local<String> property, const AccessorInfo& info) {
+  HandleScope scope;
+  Local<Object> self = info.Holder();
+  void* ptr = self->GetPointerFromInternalField(0);
+  uint32_t uid = static_cast<CpuProfile*>(ptr)->GetUid();
+  return scope.Close(Integer::NewFromUnsigned(uid));
+}
+
+
+Handle<Value> Profile::GetTitle(Local<String> property, const AccessorInfo& info) {
+  HandleScope scope;
+  Local<Object> self = info.Holder();
+  void* ptr = self->GetPointerFromInternalField(0);
+  Handle<String> title = static_cast<CpuProfile*>(ptr)->GetTitle();
+  return scope.Close(title);
+}
+
+Handle<Value> Profile::GetTopRoot(Local<String> property, const AccessorInfo& info) {
+  HandleScope scope;
+  Local<Object> self = info.Holder();
+  void* ptr = self->GetPointerFromInternalField(0);
+  const CpuProfileNode* node = static_cast<CpuProfile*>(ptr)->GetTopDownRoot();
+  return scope.Close(ProfileNode::New(node));
+}
+
+
+Handle<Value> Profile::GetBottomRoot(Local<String> property, const AccessorInfo& info) {
+  HandleScope scope;
+  Local<Object> self = info.Holder();
+  void* ptr = self->GetPointerFromInternalField(0);
+  const CpuProfileNode* node = static_cast<CpuProfile*>(ptr)->GetBottomUpRoot();
+  return scope.Close(ProfileNode::New(node));
+}
+
+Handle<Value> Profile::Delete(const Arguments& args) {
+	HandleScope scope;
+  Handle<Object> self = args.This();
+	void* ptr = self->GetPointerFromInternalField(0);
+  static_cast<CpuProfile*>(ptr)->Delete();
+	return Undefined();
+}
+
+Handle<Value> Profile::New(const CpuProfile* profile) {
+  HandleScope scope;
+  
+  if (profile_template_.IsEmpty()) {
+    Profile::Initialize();
+  }
+  
+  if(!profile) {
+    return Undefined();
+  }
+  else {
+    Local<Object> obj = profile_template_->NewInstance();
+    obj->SetPointerInInternalField(0, const_cast<CpuProfile*>(profile));
+    return scope.Close(obj);
+  }
+}
+}

--- a/lib/v8-profiler/profile.h
+++ b/lib/v8-profiler/profile.h
@@ -1,0 +1,25 @@
+#ifndef NODE_PROFILE_
+#define NODE_PROFILE_
+
+#include <v8-profiler.h>
+
+using namespace v8;
+
+namespace nodex {
+
+class Profile {
+ public:
+  static Handle<Value> New(const CpuProfile* profile);
+ 
+ private:
+  static Handle<Value> GetUid(Local<String> property, const AccessorInfo& info);
+  static Handle<Value> GetTitle(Local<String> property, const AccessorInfo& info);
+  static Handle<Value> GetTopRoot(Local<String> property, const AccessorInfo& info);
+  static Handle<Value> GetBottomRoot(Local<String> property, const AccessorInfo& info);
+  static Handle<Value> Delete(const Arguments& args);
+  static void Initialize();
+  static Persistent<ObjectTemplate> profile_template_;
+};
+
+} //namespace nodex
+#endif  // NODE_PROFILE_

--- a/lib/v8-profiler/profile_node.cc
+++ b/lib/v8-profiler/profile_node.cc
@@ -1,0 +1,126 @@
+#include "profile_node.h"
+
+using namespace v8;
+
+namespace nodex {
+
+Persistent<ObjectTemplate> ProfileNode::node_template_;
+
+void ProfileNode::Initialize() {
+  node_template_ = Persistent<ObjectTemplate>::New(ObjectTemplate::New());
+  node_template_->SetInternalFieldCount(1);
+  node_template_->SetAccessor(String::New("functionName"), ProfileNode::GetFunctionName);
+  node_template_->SetAccessor(String::New("scriptName"), ProfileNode::GetScriptName);
+  node_template_->SetAccessor(String::New("lineNumber"), ProfileNode::GetLineNumber);
+  node_template_->SetAccessor(String::New("totalTime"), ProfileNode::GetTotalTime);
+  node_template_->SetAccessor(String::New("selfTime"), ProfileNode::GetSelfTime);
+  node_template_->SetAccessor(String::New("totalSamplesCount"), ProfileNode::GetTotalSamplesCount);
+  node_template_->SetAccessor(String::New("selfSamplesCount"), ProfileNode::GetSelfSamplesCount);
+  node_template_->SetAccessor(String::New("callUid"), ProfileNode::GetCallUid);
+  node_template_->SetAccessor(String::New("childrenCount"), ProfileNode::GetChildrenCount);
+  node_template_->Set(String::New("getChild"), FunctionTemplate::New(ProfileNode::GetChild));
+}
+
+Handle<Value> ProfileNode::GetFunctionName(Local<String> property, const AccessorInfo& info) {
+  HandleScope scope;
+  Local<Object> self = info.Holder();
+  void* ptr = self->GetPointerFromInternalField(0);
+  Handle<String> fname = static_cast<CpuProfileNode*>(ptr)->GetFunctionName();
+  return scope.Close(fname);
+}
+
+Handle<Value> ProfileNode::GetScriptName(Local<String> property, const AccessorInfo& info) {
+  HandleScope scope;
+  Local<Object> self = info.Holder();
+  void* ptr = self->GetPointerFromInternalField(0);
+  Handle<String> sname = static_cast<CpuProfileNode*>(ptr)->GetScriptResourceName();
+  return scope.Close(sname);
+}
+
+Handle<Value> ProfileNode::GetLineNumber(Local<String> property, const AccessorInfo& info) {
+  HandleScope scope;
+  Local<Object> self = info.Holder();
+  void* ptr = self->GetPointerFromInternalField(0);
+  int32_t ln = static_cast<CpuProfileNode*>(ptr)->GetLineNumber();
+  return scope.Close(Integer::New(ln));
+}
+
+Handle<Value> ProfileNode::GetTotalTime(Local<String> property, const AccessorInfo& info) {
+  HandleScope scope;
+  Local<Object> self = info.Holder();
+  void* ptr = self->GetPointerFromInternalField(0);
+  double ttime = static_cast<CpuProfileNode*>(ptr)->GetTotalTime();
+  return scope.Close(Number::New(ttime));
+}
+
+Handle<Value> ProfileNode::GetSelfTime(Local<String> property, const AccessorInfo& info) {
+  HandleScope scope;
+  Local<Object> self = info.Holder();
+  void* ptr = self->GetPointerFromInternalField(0);
+  double stime = static_cast<CpuProfileNode*>(ptr)->GetSelfTime();
+  return scope.Close(Number::New(stime));
+}
+
+Handle<Value> ProfileNode::GetTotalSamplesCount(Local<String> property, const AccessorInfo& info) {
+  HandleScope scope;
+  Local<Object> self = info.Holder();
+  void* ptr = self->GetPointerFromInternalField(0);
+  double samples = static_cast<CpuProfileNode*>(ptr)->GetTotalSamplesCount();
+  return scope.Close(Number::New(samples));
+}
+
+Handle<Value> ProfileNode::GetSelfSamplesCount(Local<String> property, const AccessorInfo& info) {
+  HandleScope scope;
+  Local<Object> self = info.Holder();
+  void* ptr = self->GetPointerFromInternalField(0);
+  double samples = static_cast<CpuProfileNode*>(ptr)->GetSelfSamplesCount();
+  return scope.Close(Number::New(samples));
+}
+
+Handle<Value> ProfileNode::GetCallUid(Local<String> property, const AccessorInfo& info) {
+  HandleScope scope;
+  Local<Object> self = info.Holder();
+  void* ptr = self->GetPointerFromInternalField(0);
+  uint32_t uid = static_cast<CpuProfileNode*>(ptr)->GetCallUid();
+  return scope.Close(Integer::NewFromUnsigned(uid));
+}
+
+Handle<Value> ProfileNode::GetChildrenCount(Local<String> property, const AccessorInfo& info) {
+  HandleScope scope;
+  Local<Object> self = info.Holder();
+  void* ptr = self->GetPointerFromInternalField(0);
+  int32_t count = static_cast<CpuProfileNode*>(ptr)->GetChildrenCount();
+  return scope.Close(Integer::New(count));
+}
+
+Handle<Value> ProfileNode::GetChild(const Arguments& args) {
+  HandleScope scope;
+  if (args.Length() < 1) {
+    return ThrowException(Exception::Error(String::New("No index specified")));
+  } else if (!args[0]->IsInt32()) {
+    return ThrowException(Exception::Error(String::New("Argument must be integer")));
+  }
+  int32_t index = args[0]->Int32Value();
+  Handle<Object> self = args.This();
+  void* ptr = self->GetPointerFromInternalField(0);
+  const CpuProfileNode* node = static_cast<CpuProfileNode*>(ptr)->GetChild(index);
+  return scope.Close(ProfileNode::New(node));
+}
+
+Handle<Value> ProfileNode::New(const CpuProfileNode* node) {
+  HandleScope scope;
+  
+  if (node_template_.IsEmpty()) {
+    ProfileNode::Initialize();
+  }
+  
+  if(!node) {
+    return Undefined();
+  }
+  else {
+    Local<Object> obj = node_template_->NewInstance();
+    obj->SetPointerInInternalField(0, const_cast<CpuProfileNode*>(node));
+    return scope.Close(obj);
+  }
+}
+}

--- a/lib/v8-profiler/profile_node.h
+++ b/lib/v8-profiler/profile_node.h
@@ -1,0 +1,32 @@
+
+
+#ifndef NODE_PROFILE_NODE_
+#define NODE_PROFILE_NODE_
+
+#include <v8-profiler.h>
+
+using namespace v8;
+
+namespace nodex {
+
+class ProfileNode {
+ public:
+   static Handle<Value> New(const CpuProfileNode* node);
+
+ private:
+   static Handle<Value> GetFunctionName(Local<String> property, const AccessorInfo& info);
+   static Handle<Value> GetScriptName(Local<String> property, const AccessorInfo& info);
+   static Handle<Value> GetLineNumber(Local<String> property, const AccessorInfo& info);
+   static Handle<Value> GetTotalTime(Local<String> property, const AccessorInfo& info);
+   static Handle<Value> GetSelfTime(Local<String> property, const AccessorInfo& info);
+   static Handle<Value> GetTotalSamplesCount(Local<String> property, const AccessorInfo& info);
+   static Handle<Value> GetSelfSamplesCount(Local<String> property, const AccessorInfo& info);
+   static Handle<Value> GetCallUid(Local<String> property, const AccessorInfo& info);
+   static Handle<Value> GetChildrenCount(Local<String> property, const AccessorInfo& info);
+   static Handle<Value> GetChild(const Arguments& args);
+   static void Initialize();
+   static Persistent<ObjectTemplate> node_template_;
+};
+
+}
+#endif  // NODE_PROFILE_NODE_

--- a/lib/v8-profiler/profiler.cc
+++ b/lib/v8-profiler/profiler.cc
@@ -1,0 +1,12 @@
+#include "heap_profiler.h"
+#include "cpu_profiler.h"
+
+namespace nodex {
+  void InitializeProfiler(Handle<Object> target) {
+    HandleScope scope;
+    HeapProfiler::Initialize(target);
+    CpuProfiler::Initialize(target);
+  }
+
+  NODE_MODULE(profiler, InitializeProfiler)
+}

--- a/lib/v8-profiler/readme.md
+++ b/lib/v8-profiler/readme.md
@@ -1,0 +1,22 @@
+v8-profiler provides [node](http://github.com/ry/node) bindings for the v8 
+profiler and integration with [node-inspector](http://github.com/dannycoates/node-inspector)
+
+## Installation
+
+    npm install v8-profiler
+
+## Usage
+
+    var profiler = require('v8-profiler');
+
+## API
+
+    var snapshot = profiler.takeSnapshot([name])      //takes a heap snapshot
+
+    profiler.startProfiling([name])                   //begin cpu profiling
+    var cpuProfile = profiler.stopProfiling([name])   //finish cpu profiling
+
+## node-inspector
+
+Cpu profiles can be viewed and heap snapshots may be taken and viewed from the
+profiles panel.

--- a/lib/v8-profiler/snapshot.cc
+++ b/lib/v8-profiler/snapshot.cc
@@ -1,0 +1,172 @@
+#include "snapshot.h"
+#include "node.h"
+#include "node_buffer.h"
+
+using namespace v8;
+using namespace node;
+
+namespace nodex {
+
+Persistent<ObjectTemplate> Snapshot::snapshot_template_;
+
+void Snapshot::Initialize() {
+  snapshot_template_ = Persistent<ObjectTemplate>::New(ObjectTemplate::New());
+  snapshot_template_->SetInternalFieldCount(1);
+  snapshot_template_->SetAccessor(String::New("title"), Snapshot::GetTitle);
+  snapshot_template_->SetAccessor(String::New("uid"), Snapshot::GetUid);
+  snapshot_template_->SetAccessor(String::New("type"), Snapshot::GetType);
+  snapshot_template_->Set(String::New("delete"), FunctionTemplate::New(Snapshot::Delete));
+  snapshot_template_->Set(String::New("serialize"), FunctionTemplate::New(Snapshot::Serialize));
+}
+
+Handle<Value> Snapshot::GetTitle(Local<String> property, const AccessorInfo& info) {
+  HandleScope scope;
+  Local<Object> self = info.Holder();
+  void* ptr = self->GetPointerFromInternalField(0);
+  Handle<String> title = static_cast<HeapSnapshot*>(ptr)->GetTitle();
+  return scope.Close(title);
+}
+
+Handle<Value> Snapshot::GetUid(Local<String> property, const AccessorInfo& info) {
+  HandleScope scope;
+  Local<Object> self = info.Holder();
+  void* ptr = self->GetPointerFromInternalField(0);
+  uint32_t uid = static_cast<HeapSnapshot*>(ptr)->GetUid();
+  return scope.Close(Integer::NewFromUnsigned(uid));
+}
+
+Handle<Value> Snapshot::GetType(Local<String> property, const AccessorInfo& info) {
+  HandleScope scope;
+  Local<Object> self = info.Holder();
+  void* ptr = self->GetPointerFromInternalField(0);
+
+  HeapSnapshot::Type type = static_cast<HeapSnapshot*>(ptr)->GetType();
+  Local<String> t;
+
+  switch(type) {
+    case HeapSnapshot::kFull:
+      t = String::New("Full");
+      break;
+    default:
+      t = String::New("Unknown");
+  }
+
+  return scope.Close(t);
+}
+
+Handle<Value> Snapshot::Delete(const Arguments& args) {
+    HandleScope scope;
+    Handle<Object> self = args.This();
+    void* ptr = self->GetPointerFromInternalField(0);
+    static_cast<HeapSnapshot*>(ptr)->Delete();
+    return Undefined();
+}
+
+Handle<Value> Snapshot::New(const HeapSnapshot* snapshot) {
+  HandleScope scope;
+
+  if (snapshot_template_.IsEmpty()) {
+    Snapshot::Initialize();
+  }
+
+  if(!snapshot) {
+    return Undefined();
+  }
+  else {
+    Local<Object> obj = snapshot_template_->NewInstance();
+    obj->SetPointerInInternalField(0, const_cast<HeapSnapshot*>(snapshot));
+    return scope.Close(obj);
+  }
+}
+
+class OutputStreamAdapter : public v8::OutputStream {
+  public:
+    OutputStreamAdapter(Handle<Value> arg) {
+      Local<String> onEnd = String::New("onEnd");
+      Local<String> onData = String::New("onData");
+
+      if (!arg->IsObject()) {
+        ThrowException(Exception::TypeError(
+          String::New("You must specify an Object as first argument")));
+      }
+
+      obj = arg->ToObject();
+      if (!obj->Has(onEnd) || !obj->Has(onData)) {
+        ThrowException(Exception::TypeError(
+          String::New("You must specify properties 'onData' and 'onEnd' to invoke this function")));
+      }
+
+      if (!obj->Get(onEnd)->IsFunction() || !obj->Get(onData)->IsFunction()) {
+        ThrowException(Exception::TypeError(
+          String::New("Properties 'onData' and 'onEnd' have to be functions")));
+      }
+
+      onEndFunction = Local<Function>::Cast(obj->Get(onEnd));
+      onDataFunction = Local<Function>::Cast(obj->Get(onData));
+
+      abort = Local<Value>::New(Boolean::New(false));
+    }
+
+    void EndOfStream() {
+      TryCatch try_catch;
+      onEndFunction->Call(obj, 0, NULL);
+
+      if (try_catch.HasCaught()) {
+        FatalException(try_catch);
+      }
+    }
+
+    int GetChunkSize() {
+      return 10240;
+    }
+
+    WriteResult WriteAsciiChunk(char* data, int size) {
+      HandleScope scope;
+
+      Handle<Value> argv[2] = {
+        Buffer::New(data, size)->handle_,
+        Integer::New(size)
+      };
+
+      TryCatch try_catch;
+      abort = onDataFunction->Call(obj, 2, argv);
+
+      if (try_catch.HasCaught()) {
+        FatalException(try_catch);
+        return kAbort;
+      }
+
+      if (abort.IsEmpty() || !abort->IsBoolean()) {
+        return kContinue;
+      }
+
+      return abort->IsTrue() ? kAbort : kContinue;
+    }
+
+  private:
+    Local<Value> abort;
+    Handle<Object> obj;
+    Handle<Function> onEndFunction;
+    Handle<Function> onDataFunction;
+};
+
+Handle<Value> Snapshot::Serialize(const Arguments& args) {
+  HandleScope scope;
+  Handle<Object> self = args.This();
+
+  uint32_t argslen = args.Length();
+
+  if (argslen == 0) {
+    return ThrowException(Exception::TypeError(
+      String::New("You must specify arguments to invoke this function")));
+  }
+
+  OutputStreamAdapter *stream = new OutputStreamAdapter(args[0]);
+
+  void* ptr = self->GetPointerFromInternalField(0);
+  static_cast<HeapSnapshot*>(ptr)->Serialize(stream, HeapSnapshot::kJSON);
+
+  return Undefined();
+}
+
+} //namespace nodex

--- a/lib/v8-profiler/snapshot.h
+++ b/lib/v8-profiler/snapshot.h
@@ -1,0 +1,39 @@
+
+
+#ifndef NODE_SNAPSHOT_
+#define NODE_SNAPSHOT_
+
+#include <v8-profiler.h>
+
+using namespace v8;
+
+namespace nodex {
+
+class Snapshot {
+  public:
+    static Handle<Value> New(const HeapSnapshot* snapshot);
+
+  private:
+    Snapshot(const v8::HeapSnapshot* snapshot)
+        : m_snapshot(snapshot){}
+
+    const v8::HeapSnapshot* m_snapshot;
+
+    static Handle<Value> GetUid(Local<String> property, const AccessorInfo& info);
+    static Handle<Value> GetTitle(Local<String> property, const AccessorInfo& info);
+    static Handle<Value> GetMaxSnapshotJSObjectId(Local<String> property, const AccessorInfo& info);
+    static Handle<Value> GetRoot(Local<String> property, const AccessorInfo& info);
+    static Handle<Value> GetType(Local<String> property, const AccessorInfo& info);
+    static Handle<Value> GetNodesCount(Local<String> property, const AccessorInfo& info);
+    static Handle<Value> GetNodeById(const Arguments& args);
+    static Handle<Value> GetNode(const Arguments& args);
+    static Handle<Value> Delete(const Arguments& args);
+    static Handle<Value> Serialize(const Arguments& args);
+
+    static Handle<Value> SnapshotObjectId(const Arguments& args);
+
+    static void Initialize();
+    static Persistent<ObjectTemplate> snapshot_template_;
+};
+} //namespace nodex
+#endif  // NODE_SNAPSHOT_

--- a/lib/v8-profiler/v8-profiler.js
+++ b/lib/v8-profiler/v8-profiler.js
@@ -1,0 +1,245 @@
+var binding = require("./profiler");
+
+function Snapshot() {}
+
+Snapshot.prototype.compare = function (other) {
+  var my_objects = this.nodeCounts(),
+      their_objects = other.nodeCounts(),
+      diff = {}, i, k, my_val, their_val;
+      all_keys = Object.keys(my_objects).concat(Object.keys(their_objects)); //has dupes, oh well
+  for (i = 0; i < all_keys.length; i++) {
+    k = all_keys[i];
+    my_val = my_objects[k] || 0;
+    their_val = their_objects[k] || 0;
+    diff[k] = their_val - my_val;
+  }
+  return diff;
+};
+
+Snapshot.prototype.hotPath = function() {
+  var path = [], node = this.root, c, i = 0;
+  c = this.children(node);
+  while (c.length > 0 && i < 1000) {
+    node = c[0].to;
+    c = this.children(node);
+    path.push(node);
+    i++;
+  }
+  return path;
+};
+
+Snapshot.prototype.children = function(node) {
+  var i, children = [];
+  for(i = 0; i < node.childrenCount; i++) {
+    children[i] = node.getChild(i);
+  }
+  children.sort(function (a, b){
+    return b.to.retainedSize() - a.to.retainedSize();
+  });
+  return children;
+};
+
+Snapshot.prototype.topDominatorIds = function() {
+  var doms = {}, arr;
+  this.allNodes().forEach(function(node){
+    var dom = node.dominatorNode || { id: "none"};
+    if (doms[dom.id]) {
+      doms[dom.id] += 1;
+    }
+    else {
+      doms[dom.id] = 1;
+    }
+  });
+  arr = Object.keys(doms).map(function(d){
+    return {id: d, count: doms[d]};
+  });
+  arr.sort(function(a, b) {
+    return b.count - a.count;
+  });
+  return arr;
+};
+
+Snapshot.prototype.topDominators = function() {
+  var self = this;
+  return this.topDominatorIds().map(function(d){
+    return self.getNodeById(+d.id);
+  });
+};
+
+Snapshot.prototype.allNodes = function() {
+  var n = this.nodesCount, i, nodes = [];
+  for (i = 0; i < n; i++) {
+    nodes[i] = this.getNode(i);
+  }
+  return nodes;
+};
+
+Snapshot.prototype.nodeCounts = function() {
+  var objects = {};
+  this.allNodes().forEach(function(n){
+    if(n.type === "Object") {
+      if (objects[n.name]) {
+        objects[n.name] += 1;
+      }
+      else {
+        objects[n.name] = 1;
+      }
+    }
+    else {
+      if (objects[n.type]) {
+        objects[n.type] += 1;
+      }
+      else {
+        objects[n.type] = 1;
+      }
+    }
+  });
+  return objects;
+};
+
+//adapted from WebCore/bindings/v8/ScriptHeapSnapshot.cpp
+Snapshot.prototype.stringify = function() {
+  var root = this.root, i, j, count_i, count_j, node,
+      lowLevels = {}, entries = {}, entry,
+      children = {}, child, edge, result = {};
+  for (i = 0, count_i = root.childrenCount; i < count_i; i++) {
+    node = root.getChild(i).to;
+    if (node.type === 'Hidden') {
+      lowLevels[node.name] = {
+        count: node.instancesCount,
+        size: node.size,
+        type: node.name
+      };
+    }
+    else if (node.instancesCount > 0) {
+      entries[node.name] = {
+        constructorName: node.name,
+        count: node.instancesCount,
+        size: node.size
+      };
+    }
+    // FIXME: the children portion is too slow and bloats the results
+    //*
+    else {
+      entry = {
+        constructorName: node.name
+      };
+      for(j = 0, count_j = node.childrenCount; j < count_j; j++) {
+        edge = node.getChild(j);
+        child = edge.to;
+        entry[child.ptr.toString()] = {
+          constructorName: child.name,
+          count: parseInt(edge.name, 10)
+        };
+      }
+      children[node.ptr.toString()] = entry;
+    }//*/
+  }
+  result.lowlevels = lowLevels;
+  result.entries = entries;
+  result.children = children;
+  return JSON.stringify(result);
+};
+
+function CpuProfile() {}
+
+function inspectorObjectFor(node) {
+  var i, count, child,
+      result = {
+        functionName: node.functionName,
+        url: node.scriptName,
+        lineNumber: node.lineNumber,
+        totalTime: node.totalTime,
+        selfTime: node.selfTime,
+        numberOfCalls: 0,
+        visible: true,
+        callUID: node.callUid,
+        children: []
+      };
+  for(i = 0, count = node.childrenCount; i < count; i++) {
+    child = node.getChild(i);
+    result.children.push(inspectorObjectFor(child));
+  }
+  return result;
+}
+
+CpuProfile.prototype.getTopDownRoot = function() {
+  return inspectorObjectFor(this.topRoot);
+};
+
+CpuProfile.prototype.getBottomUpRoot = function() {
+  return inspectorObjectFor(this.bottomRoot);
+};
+
+var heapCache = [];
+
+exports.takeSnapshot = function(name, control) {
+  if (typeof name == 'function') {
+    control = name;
+    name = '';
+  }
+
+  if (!name || !name.length) {
+    name = 'org.nodejs.profiles.heap.user-initiated.' + (heapCache.length + 1);
+  }
+
+  var snapshot = binding.heapProfiler.takeSnapshot(name, control);
+  snapshot.__proto__ = Snapshot.prototype;
+  heapCache.push(snapshot);
+
+  return snapshot;
+};
+
+exports.getSnapshot = function(index) {
+  return heapCache[index];
+};
+
+exports.findSnapshot = function(uid) {
+  return heapCache.filter(function(s) {return s.uid === uid;})[0];
+};
+
+exports.snapshotCount = function() {
+  return heapCache.length;
+};
+
+exports.deleteAllSnapshots = function () {
+	heapCache = [];
+	binding.heapProfiler.deleteAllSnapshots();
+};
+
+var cpuCache = [];
+
+exports.startProfiling = function(name) {
+  if (!name || !name.length) {
+    name = 'org.nodejs.profiles.cpu.user-initiated.' + (cpuCache.length + 1);
+  }
+
+  binding.cpuProfiler.startProfiling(name);
+};
+
+exports.stopProfiling = function(name) {
+  name = name ? name : '';
+  var profile = binding.cpuProfiler.stopProfiling(name);
+  profile.__proto__ = CpuProfile.prototype;
+  cpuCache.push(profile);
+  return profile;
+};
+
+exports.getProfile = function(index) {
+  return cpuCache[index];
+};
+
+exports.findProfile = function(uid) {
+  return cpuCache.filter(function(s) {return s.uid === uid;})[0];
+};
+
+exports.profileCount = function() {
+  return cpuCache.length;
+};
+
+exports.deleteAllProfiles = function() {
+  cpuCache = [];
+  binding.cpuProfiler.deleteAllProfiles();
+};
+
+process.profiler = exports;

--- a/lib/v8-profiler/wscript
+++ b/lib/v8-profiler/wscript
@@ -1,0 +1,15 @@
+srcdir  = '.'
+blddir  = 'build'
+VERSION = '0.1.0'
+
+def set_options(ctx):
+  ctx.tool_options('compiler_cxx')
+
+def configure(ctx):
+  ctx.check_tool('compiler_cxx')
+  ctx.check_tool('node_addon')
+
+def build(ctx):
+  t = ctx.new_task_gen('cxx', 'shlib', 'node_addon')
+  t.target = 'profiler'
+  t.source = ctx.path.ant_glob('*.cc')

--- a/package.json
+++ b/package.json
@@ -22,9 +22,12 @@
     "should": "0.6.0"
   },
   "dependencies": {
-    "v8-profiler": "git://github.com/c4milo/v8-profiler.git#v4.0.0",
+    "v8-profiler": "*",
     "ws": "0.4.25",
     "underscore": "1.3.3"
   },
-  "main": "index"
+  "main": "index",
+  "scripts": {
+    "preinstall": "npm install ./lib/v8-profiler"
+  }
 }


### PR DESCRIPTION
Resolves issue #10 and obsoletes PR #38 by bundling your modified v8-profiler fork.

Downside: it uses a preinstall script, which is an explicit npm antipattern. But frankly, I think it's the right way to go, here. And easy, too. :smile: 
