### PR TITLE
Fix building on Windows 7 x64

### DIFF
--- a/src/heap_profiler.h
+++ b/src/heap_profiler.h
@@ -1,8 +1,8 @@
 #ifndef NODE_HEAP_PROFILER_
 #define NODE_HEAP_PROFILER_
 
-#include <v8-profiler.h>
 #include <node.h>
+#include <v8-profiler.h>
 
 using namespace v8;
 using namespace node;


### PR DESCRIPTION
- tried the fix listed here, and it worked: https://groups.google.com/forum/#!topic/nodejs/onA0S01INtw
- have not proved that it will work everywhere, but it's worth a shot

Related to #46.

EDIT: I forgot to mention, you should probably switch the order of #includes in cpu_profiler.h as well, and maybe add `#include <node.h>` to all your .cc files.  I'm not sure.
