### PR TITLE
Frontend socket close support to avoid exceptions.

### DIFF
--- a/webkit-devtools-agent.js
+++ b/webkit-devtools-agent.js
@@ -59,6 +59,8 @@ var DevToolsAgentProxy = module.exports = function() {
         this.frontend = socket;
 
         this.frontend.on('message', this.onFrontendMessage.bind(this));
+        
+        this.frontend.on('close', (function(){ this.frontend = null;}).bind(this));
 
         if(this.log === true)
             console.log('webkit-devtools-agent: new frontend connection!');


### PR DESCRIPTION
Frontend websocket close was not properly detected causing exception on following console.log through onBackendMessage.
