### PR TITLE
Add link to dev.chrome for detailed heap-snap comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ process.on('SIGUSR2', function () {
 ### Heap Profiling
 ![Screenshot](https://i.cloudup.com/WR5MKG6i02.png)
 
+For detailed information on debugging memory leaks using devtools' heap comparisons (using this module), follow [this tutorial](https://developer.chrome.com/devtools/docs/javascript-memory-profiling).
+
 
 Happy Debugging!
 


### PR DESCRIPTION
Took me a while to stumble upon this article, which is what really made node-webkit-agent so valuable for debugging memleaks in the end. Would be a useful link to throw in README
