### PR TITLE
Port to nan for compatibility with newer V8/Node versions.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,6 +2,9 @@
   'targets': [
     {
       'target_name': 'profiler',
+       'include_dirs' : [
+            'node_modules/nan',
+       ],
       'sources': [
         'src/cpu_profiler.cc',
         'src/heap_profiler.cc',

--- a/lib/profiler.js
+++ b/lib/profiler.js
@@ -162,8 +162,15 @@ function ProfilerAgent(notify) {
         sendResult({});
     };
 
+    var fakeProfileUid = 1;
+
     this.stop = function (params, sendResult) {
         var profile = profiler.stopProfiling();
+
+        // forwards compatibility for newer V8 in node 0.12 which doesn't set profile.uid
+        if (!profile.hasOwnProperty('uid')) {
+            profile.uid = fakeProfileUid++;
+        }
 
         this.profiles[CPUProfileType][profile.uid] = profile;
 

--- a/lib/v8-profiler.js
+++ b/lib/v8-profiler.js
@@ -149,8 +149,11 @@ function inspectorObjectFor(node) {
         functionName: node.functionName,
         url: node.scriptName,
         lineNumber: node.lineNumber,
+        // NodeJS until 0.10 only
         totalTime: node.totalTime,
         selfTime: node.selfTime,
+        // hitCount is defined by NodeJS 0.12+ only
+        hitCount: node.hitCount, // Would the UI want to show this? v8 3.14 had this as selfSamplesCount which this UI doesn't use.
         numberOfCalls: 0,
         visible: true,
         callUID: node.callUid,

--- a/lib/v8-profiler.js
+++ b/lib/v8-profiler.js
@@ -168,6 +168,10 @@ CpuProfile.prototype.getTopDownRoot = function () {
 };
 
 CpuProfile.prototype.getBottomUpRoot = function () {
+  // Newer V8 (node 0.12) doesn't have bottom-up profiling?
+  if (!this.bottomRoot) {
+    return null;
+  }
   return inspectorObjectFor(this.bottomRoot);
 };
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "should": "0.6.0"
   },
   "dependencies": {
+    "nan": "1.6.2",
     "ws": "0.4.31",
     "underscore": "1.3.3"
   },

--- a/src/cpu_profiler.cc
+++ b/src/cpu_profiler.cc
@@ -13,12 +13,16 @@ namespace nodex {
 
         Local<Object> cpuProfilerObj = cpu_profiler_template->NewInstance();
 
+#if (NODE_MODULE_VERSION < 12)
         NODE_SET_METHOD(cpuProfilerObj, "getProfilesCount", CpuProfiler::GetProfilesCount);
         NODE_SET_METHOD(cpuProfilerObj, "getProfile", CpuProfiler::GetProfile);
         NODE_SET_METHOD(cpuProfilerObj, "findProfile", CpuProfiler::FindProfile);
+#endif // (NODE_MODULE_VERSION < 12)
         NODE_SET_METHOD(cpuProfilerObj, "startProfiling", CpuProfiler::StartProfiling);
         NODE_SET_METHOD(cpuProfilerObj, "stopProfiling", CpuProfiler::StopProfiling);
+#if (NODE_MODULE_VERSION < 12)
         NODE_SET_METHOD(cpuProfilerObj, "deleteAllProfiles", CpuProfiler::DeleteAllProfiles);
+#endif // (NODE_MODULE_VERSION < 12)
 
         target->Set(NanNew<String>("cpuProfiler"), cpuProfilerObj);
     }
@@ -26,6 +30,7 @@ namespace nodex {
     CpuProfiler::CpuProfiler() {}
     CpuProfiler::~CpuProfiler() {}
 
+#if (NODE_MODULE_VERSION < 12)
     NAN_METHOD(CpuProfiler::GetProfilesCount) {
         NanScope();
         NanReturnValue(NanNew<Integer>(v8::CpuProfiler::GetProfilesCount()));
@@ -54,24 +59,35 @@ namespace nodex {
         const CpuProfile* profile = v8::CpuProfiler::FindProfile(uid);
         NanReturnValue(Profile::New(profile));
     }
+#endif // (NODE_MODULE_VERSION < 12)
 
     NAN_METHOD(CpuProfiler::StartProfiling) {
         NanScope();
         Local<String> title = args.Length() > 0 ? args[0]->ToString() : NanNew<String>("");
+#if (NODE_MODULE_VERSION < 12)
         v8::CpuProfiler::StartProfiling(title);
+#else // (NODE_MODULE_VERSION < 12)
+        v8::Isolate::GetCurrent()->GetCpuProfiler()->StartProfiling(title);
+#endif // (NODE_MODULE_VERSION < 12)
         NanReturnUndefined();
     }
 
     NAN_METHOD(CpuProfiler::StopProfiling) {
         NanScope();
         Local<String> title = args.Length() > 0 ? args[0]->ToString() : NanNew<String>("");
+#if (NODE_MODULE_VERSION < 12)
         const CpuProfile* profile = v8::CpuProfiler::StopProfiling(title);
+#else // (NODE_MODULE_VERSION < 12)
+        const CpuProfile* profile = v8::Isolate::GetCurrent()->GetCpuProfiler()->StopProfiling(title);
+#endif // (NODE_MODULE_VERSION < 12)
         NanReturnValue(Profile::New(profile));
     }
 
+#if (NODE_MODULE_VERSION < 12)
     NAN_METHOD(CpuProfiler::DeleteAllProfiles) {
         v8::CpuProfiler::DeleteAllProfiles();
         NanReturnUndefined();
     }
+#endif // (NODE_MODULE_VERSION < 12)
 
 } //namespace nodex

--- a/src/cpu_profiler.cc
+++ b/src/cpu_profiler.cc
@@ -5,12 +5,13 @@ namespace nodex {
     Persistent<ObjectTemplate> CpuProfiler::cpu_profiler_template_;
 
     void CpuProfiler::Initialize(Handle<Object> target) {
-        HandleScope scope;
+        NanScope();
 
-        cpu_profiler_template_ = Persistent<ObjectTemplate>::New(ObjectTemplate::New());
-        cpu_profiler_template_->SetInternalFieldCount(1);
+        Handle<ObjectTemplate> cpu_profiler_template = ObjectTemplate::New();
+        NanAssignPersistent(cpu_profiler_template_, cpu_profiler_template);
+        cpu_profiler_template->SetInternalFieldCount(1);
 
-        Local<Object> cpuProfilerObj = cpu_profiler_template_->NewInstance();
+        Local<Object> cpuProfilerObj = cpu_profiler_template->NewInstance();
 
         NODE_SET_METHOD(cpuProfilerObj, "getProfilesCount", CpuProfiler::GetProfilesCount);
         NODE_SET_METHOD(cpuProfilerObj, "getProfile", CpuProfiler::GetProfile);
@@ -19,57 +20,58 @@ namespace nodex {
         NODE_SET_METHOD(cpuProfilerObj, "stopProfiling", CpuProfiler::StopProfiling);
         NODE_SET_METHOD(cpuProfilerObj, "deleteAllProfiles", CpuProfiler::DeleteAllProfiles);
 
-        target->Set(String::NewSymbol("cpuProfiler"), cpuProfilerObj);
+        target->Set(NanNew<String>("cpuProfiler"), cpuProfilerObj);
     }
 
     CpuProfiler::CpuProfiler() {}
     CpuProfiler::~CpuProfiler() {}
 
-    Handle<Value> CpuProfiler::GetProfilesCount(const Arguments& args) {
-        HandleScope scope;
-        return scope.Close(Integer::New(v8::CpuProfiler::GetProfilesCount()));
+    NAN_METHOD(CpuProfiler::GetProfilesCount) {
+        NanScope();
+        NanReturnValue(NanNew<Integer>(v8::CpuProfiler::GetProfilesCount()));
     }
 
-    Handle<Value> CpuProfiler::GetProfile(const Arguments& args) {
-        HandleScope scope;
+    NAN_METHOD(CpuProfiler::GetProfile) {
+        NanScope();
         if (args.Length() < 1) {
-            return ThrowException(Exception::Error(String::New("No index specified")));
+            NanThrowError("No index specified");
         } else if (!args[0]->IsInt32()) {
-            return ThrowException(Exception::TypeError(String::New("Argument must be an integer")));
+            NanThrowTypeError("Argument must be an integer");
         }
         int32_t index = args[0]->Int32Value();
         const CpuProfile* profile = v8::CpuProfiler::GetProfile(index);
-        return scope.Close(Profile::New(profile));
+        NanReturnValue(Profile::New(profile));
     }
 
-    Handle<Value> CpuProfiler::FindProfile(const Arguments& args) {
-        HandleScope scope;
+    NAN_METHOD(CpuProfiler::FindProfile) {
+        NanScope();
         if (args.Length() < 1) {
-            return ThrowException(Exception::Error(String::New("No index specified")));
+            NanThrowError("No index specified");
         } else if (!args[0]->IsInt32()) {
-            return ThrowException(Exception::TypeError(String::New("Argument must be an integer")));
+            NanThrowTypeError("Argument must be an integer");
         }
         uint32_t uid = args[0]->Uint32Value();
         const CpuProfile* profile = v8::CpuProfiler::FindProfile(uid);
-        return scope.Close(Profile::New(profile));
+        NanReturnValue(Profile::New(profile));
     }
 
-    Handle<Value> CpuProfiler::StartProfiling(const Arguments& args) {
-        HandleScope scope;
-        Local<String> title = args.Length() > 0 ? args[0]->ToString() : String::New("");
+    NAN_METHOD(CpuProfiler::StartProfiling) {
+        NanScope();
+        Local<String> title = args.Length() > 0 ? args[0]->ToString() : NanNew<String>("");
         v8::CpuProfiler::StartProfiling(title);
-        return Undefined();
+        NanReturnUndefined();
     }
 
-    Handle<Value> CpuProfiler::StopProfiling(const Arguments& args) {
-        HandleScope scope;
-        Local<String> title = args.Length() > 0 ? args[0]->ToString() : String::New("");
+    NAN_METHOD(CpuProfiler::StopProfiling) {
+        NanScope();
+        Local<String> title = args.Length() > 0 ? args[0]->ToString() : NanNew<String>("");
         const CpuProfile* profile = v8::CpuProfiler::StopProfiling(title);
-        return scope.Close(Profile::New(profile));
+        NanReturnValue(Profile::New(profile));
     }
 
-    Handle<Value> CpuProfiler::DeleteAllProfiles(const Arguments& args) {
+    NAN_METHOD(CpuProfiler::DeleteAllProfiles) {
         v8::CpuProfiler::DeleteAllProfiles();
-        return Undefined();
+        NanReturnUndefined();
     }
+
 } //namespace nodex

--- a/src/cpu_profiler.cc
+++ b/src/cpu_profiler.cc
@@ -67,7 +67,7 @@ namespace nodex {
 #if (NODE_MODULE_VERSION < 12)
         v8::CpuProfiler::StartProfiling(title);
 #else // (NODE_MODULE_VERSION < 12)
-        v8::Isolate::GetCurrent()->GetCpuProfiler()->StartProfiling(title);
+        v8::Isolate::GetCurrent()->GetCpuProfiler()->StartProfiling(title, true);
 #endif // (NODE_MODULE_VERSION < 12)
         NanReturnUndefined();
     }

--- a/src/cpu_profiler.h
+++ b/src/cpu_profiler.h
@@ -3,6 +3,7 @@
 
 #include <node.h>
 #include <v8-profiler.h>
+#include <nan.h>
 	
 using namespace v8;
 using namespace node;
@@ -16,12 +17,12 @@ namespace nodex {
             virtual ~CpuProfiler();
 
         protected:
-            static Handle<Value> GetProfilesCount(const Arguments& args);
-            static Handle<Value> GetProfile(const Arguments& args);
-            static Handle<Value> FindProfile(const Arguments& args);
-            static Handle<Value> StartProfiling(const Arguments& args);
-            static Handle<Value> StopProfiling(const Arguments& args);
-            static Handle<Value> DeleteAllProfiles(const Arguments& args);
+            static NAN_METHOD(GetProfilesCount);
+            static NAN_METHOD(GetProfile);
+            static NAN_METHOD(FindProfile);
+            static NAN_METHOD(StartProfiling);
+            static NAN_METHOD(StopProfiling);
+            static NAN_METHOD(DeleteAllProfiles);
 
         private:
             static Persistent<ObjectTemplate> cpu_profiler_template_;

--- a/src/heap_profiler.cc
+++ b/src/heap_profiler.cc
@@ -52,7 +52,9 @@ namespace nodex {
 
         NODE_SET_METHOD(heapProfilerObj, "takeSnapshot", HeapProfiler::TakeSnapshot);
         NODE_SET_METHOD(heapProfilerObj, "getSnapshot", HeapProfiler::GetSnapshot);
+#if (NODE_MODULE_VERSION < 12)
         NODE_SET_METHOD(heapProfilerObj, "findSnapshot", HeapProfiler::FindSnapshot);
+#endif // (NODE_MODULE_VERSION < 12)
         NODE_SET_METHOD(heapProfilerObj, "getSnapshotsCount", HeapProfiler::GetSnapshotsCount);
         NODE_SET_METHOD(heapProfilerObj, "deleteAllSnapshots", HeapProfiler::DeleteAllSnapshots);
 
@@ -64,7 +66,11 @@ namespace nodex {
 
     NAN_METHOD(HeapProfiler::GetSnapshotsCount) {
         NanScope();
+#if (NODE_MODULE_VERSION < 12)
         NanReturnValue(NanNew<Integer>(v8::HeapProfiler::GetSnapshotsCount()));
+#else // (NODE_MODULE_VERSION < 12)
+        NanReturnValue(NanNew<Integer>(v8::Isolate::GetCurrent()->GetHeapProfiler()->GetSnapshotCount()));
+#endif // (NODE_MODULE_VERSION < 12)
     }
 
     NAN_METHOD(HeapProfiler::GetSnapshot) {
@@ -75,11 +81,16 @@ namespace nodex {
             NanThrowTypeError("Argument must be an integer");
         }
         int32_t index = args[0]->Int32Value();
+#if (NODE_MODULE_VERSION < 12)
         const v8::HeapSnapshot* snapshot = v8::HeapProfiler::GetSnapshot(index);
+#else // (NODE_MODULE_VERSION < 12)
+        const v8::HeapSnapshot* snapshot = v8::Isolate::GetCurrent()->GetHeapProfiler()->GetHeapSnapshot(index);
+#endif // (NODE_MODULE_VERSION < 12)
 
         NanReturnValue(Snapshot::New(snapshot));
     }
 
+#if (NODE_MODULE_VERSION < 12)
     NAN_METHOD(HeapProfiler::FindSnapshot) {
         NanScope();
         if (args.Length() < 1) {
@@ -91,6 +102,7 @@ namespace nodex {
 
         NanReturnValue(Snapshot::New(snapshot));
     }
+#endif // (NODE_MODULE_VERSION < 12)
 
     NAN_METHOD(HeapProfiler::TakeSnapshot) {
         NanScope();
@@ -117,14 +129,22 @@ namespace nodex {
             }
         }
 
+#if (NODE_MODULE_VERSION < 12)
         const v8::HeapSnapshot* snapshot = v8::HeapProfiler::TakeSnapshot(title, HeapSnapshot::kFull, control);
+#else // (NODE_MODULE_VERSION < 12)
+        const v8::HeapSnapshot* snapshot = v8::Isolate::GetCurrent()->GetHeapProfiler()->TakeHeapSnapshot(title, control);
+#endif // (NODE_MODULE_VERSION < 12)
 
         NanReturnValue(Snapshot::New(snapshot));
     }
 
     NAN_METHOD(HeapProfiler::DeleteAllSnapshots) {
         NanScope();
+#if (NODE_MODULE_VERSION < 12)
         v8::HeapProfiler::DeleteAllSnapshots();
+#else // (NODE_MODULE_VERSION < 12)
+        v8::Isolate::GetCurrent()->GetHeapProfiler()->DeleteAllHeapSnapshots();
+#endif // (NODE_MODULE_VERSION < 12)
         NanReturnUndefined();
     }
 } //namespace nodex

--- a/src/heap_profiler.h
+++ b/src/heap_profiler.h
@@ -3,6 +3,7 @@
 
 #include <node.h>
 #include <v8-profiler.h>
+#include <nan.h>
 
 using namespace v8;
 using namespace node;
@@ -16,11 +17,11 @@ namespace nodex {
             virtual ~HeapProfiler();
 
         protected:
-            static Handle<Value> GetSnapshotsCount(const Arguments& args);
-            static Handle<Value> GetSnapshot(const Arguments& args);
-            static Handle<Value> FindSnapshot(const Arguments& args);
-            static Handle<Value> TakeSnapshot(const Arguments& args);
-            static Handle<Value> DeleteAllSnapshots(const Arguments& args);
+            static NAN_METHOD(GetSnapshotsCount);
+            static NAN_METHOD(GetSnapshot);
+            static NAN_METHOD(FindSnapshot);
+            static NAN_METHOD(TakeSnapshot);
+            static NAN_METHOD(DeleteAllSnapshots);
 
         private:
             static Persistent<ObjectTemplate> heap_profiler_template_;

--- a/src/profile.cc
+++ b/src/profile.cc
@@ -8,71 +8,73 @@ namespace nodex {
 Persistent<ObjectTemplate> Profile::profile_template_;
 
 void Profile::Initialize() {
-  profile_template_ = Persistent<ObjectTemplate>::New(ObjectTemplate::New());
-  profile_template_->SetInternalFieldCount(1);
-  profile_template_->SetAccessor(String::New("title"), Profile::GetTitle);
-  profile_template_->SetAccessor(String::New("uid"), Profile::GetUid);
-  profile_template_->SetAccessor(String::New("topRoot"), Profile::GetTopRoot);
-  profile_template_->SetAccessor(String::New("bottomRoot"), Profile::GetBottomRoot);
-  profile_template_->Set(String::New("delete"), FunctionTemplate::New(Profile::Delete));
+  Handle<ObjectTemplate> profile_template = ObjectTemplate::New();
+  NanAssignPersistent(profile_template_, profile_template);
+  profile_template->SetInternalFieldCount(1);
+  profile_template->SetAccessor(NanNew<String>("title"), Profile::GetTitle);
+  profile_template->SetAccessor(NanNew<String>("uid"), Profile::GetUid);
+  profile_template->SetAccessor(NanNew<String>("topRoot"), Profile::GetTopRoot);
+  profile_template->SetAccessor(NanNew<String>("bottomRoot"), Profile::GetBottomRoot);
+  profile_template->Set(NanNew<String>("delete"), NanNew<FunctionTemplate>(Profile::Delete));
 }
 
-Handle<Value> Profile::GetUid(Local<String> property, const AccessorInfo& info) {
-  HandleScope scope;
-  Local<Object> self = info.Holder();
-  void* ptr = self->GetPointerFromInternalField(0);
+NAN_PROPERTY_GETTER(Profile::GetUid) {
+  NanScope();
+  Local<Object> self = args.Holder();
+  void* ptr = NanGetInternalFieldPointer(self, 0);
   uint32_t uid = static_cast<CpuProfile*>(ptr)->GetUid();
-  return scope.Close(Integer::NewFromUnsigned(uid));
+  NanReturnValue(NanNew<Integer>(uid));
 }
 
 
-Handle<Value> Profile::GetTitle(Local<String> property, const AccessorInfo& info) {
-  HandleScope scope;
-  Local<Object> self = info.Holder();
-  void* ptr = self->GetPointerFromInternalField(0);
+NAN_PROPERTY_GETTER(Profile::GetTitle) {
+  NanScope();
+  Local<Object> self = args.Holder();
+  void* ptr = NanGetInternalFieldPointer(self, 0);
   Handle<String> title = static_cast<CpuProfile*>(ptr)->GetTitle();
-  return scope.Close(title);
+  NanReturnValue(title);
 }
 
-Handle<Value> Profile::GetTopRoot(Local<String> property, const AccessorInfo& info) {
-  HandleScope scope;
-  Local<Object> self = info.Holder();
-  void* ptr = self->GetPointerFromInternalField(0);
+NAN_PROPERTY_GETTER(Profile::GetTopRoot) {
+  NanScope();
+  Local<Object> self = args.Holder();
+  void* ptr = NanGetInternalFieldPointer(self, 0);
   const CpuProfileNode* node = static_cast<CpuProfile*>(ptr)->GetTopDownRoot();
-  return scope.Close(ProfileNode::New(node));
+  NanReturnValue(ProfileNode::New(node));
 }
 
 
-Handle<Value> Profile::GetBottomRoot(Local<String> property, const AccessorInfo& info) {
-  HandleScope scope;
-  Local<Object> self = info.Holder();
-  void* ptr = self->GetPointerFromInternalField(0);
+NAN_PROPERTY_GETTER(Profile::GetBottomRoot) {
+  NanScope();
+  Local<Object> self = args.Holder();
+  void* ptr = NanGetInternalFieldPointer(self, 0);
   const CpuProfileNode* node = static_cast<CpuProfile*>(ptr)->GetBottomUpRoot();
-  return scope.Close(ProfileNode::New(node));
+  NanReturnValue(ProfileNode::New(node));
 }
 
-Handle<Value> Profile::Delete(const Arguments& args) {
-	HandleScope scope;
+NAN_METHOD(Profile::Delete) {
+  NanScope();
   Handle<Object> self = args.This();
-	void* ptr = self->GetPointerFromInternalField(0);
+  void* ptr = NanGetInternalFieldPointer(self, 0);
   static_cast<CpuProfile*>(ptr)->Delete();
-	return Undefined();
+  NanReturnUndefined();
 }
 
 Handle<Value> Profile::New(const CpuProfile* profile) {
-  HandleScope scope;
-  
+  NanEscapableScope();
+
   if (profile_template_.IsEmpty()) {
     Profile::Initialize();
   }
-  
+
   if(!profile) {
-    return Undefined();
+    return NanUndefined();
   }
   else {
-    Local<Object> obj = profile_template_->NewInstance();
-    obj->SetPointerInInternalField(0, const_cast<CpuProfile*>(profile));
-    return scope.Close(obj);
+    Local<Object> obj = NanNew<ObjectTemplate>(profile_template_)->NewInstance();
+    NanSetInternalFieldPointer(obj, 0, const_cast<CpuProfile*>(profile));
+    return NanEscapeScope(obj);
   }
 }
-}
+
+} // namespace nodex

--- a/src/profile.cc
+++ b/src/profile.cc
@@ -12,12 +12,17 @@ void Profile::Initialize() {
   NanAssignPersistent(profile_template_, profile_template);
   profile_template->SetInternalFieldCount(1);
   profile_template->SetAccessor(NanNew<String>("title"), Profile::GetTitle);
+#if (NODE_MODULE_VERSION < 12)
   profile_template->SetAccessor(NanNew<String>("uid"), Profile::GetUid);
+#endif // (NODE_MODULE_VERSION < 12)
   profile_template->SetAccessor(NanNew<String>("topRoot"), Profile::GetTopRoot);
+#if (NODE_MODULE_VERSION < 12)
   profile_template->SetAccessor(NanNew<String>("bottomRoot"), Profile::GetBottomRoot);
+#endif // (NODE_MODULE_VERSION < 12)
   profile_template->Set(NanNew<String>("delete"), NanNew<FunctionTemplate>(Profile::Delete));
 }
 
+#if (NODE_MODULE_VERSION < 12)
 NAN_PROPERTY_GETTER(Profile::GetUid) {
   NanScope();
   Local<Object> self = args.Holder();
@@ -25,6 +30,7 @@ NAN_PROPERTY_GETTER(Profile::GetUid) {
   uint32_t uid = static_cast<CpuProfile*>(ptr)->GetUid();
   NanReturnValue(NanNew<Integer>(uid));
 }
+#endif // (NODE_MODULE_VERSION < 12)
 
 
 NAN_PROPERTY_GETTER(Profile::GetTitle) {
@@ -44,6 +50,7 @@ NAN_PROPERTY_GETTER(Profile::GetTopRoot) {
 }
 
 
+#if (NODE_MODULE_VERSION < 12)
 NAN_PROPERTY_GETTER(Profile::GetBottomRoot) {
   NanScope();
   Local<Object> self = args.Holder();
@@ -51,6 +58,7 @@ NAN_PROPERTY_GETTER(Profile::GetBottomRoot) {
   const CpuProfileNode* node = static_cast<CpuProfile*>(ptr)->GetBottomUpRoot();
   NanReturnValue(ProfileNode::New(node));
 }
+#endif // (NODE_MODULE_VERSION < 12)
 
 NAN_METHOD(Profile::Delete) {
   NanScope();

--- a/src/profile.h
+++ b/src/profile.h
@@ -3,6 +3,7 @@
 
 #include <node.h>
 #include <v8-profiler.h>
+#include <nan.h>
 
 using namespace v8;
 
@@ -13,11 +14,11 @@ class Profile {
   static Handle<Value> New(const CpuProfile* profile);
  
  private:
-  static Handle<Value> GetUid(Local<String> property, const AccessorInfo& info);
-  static Handle<Value> GetTitle(Local<String> property, const AccessorInfo& info);
-  static Handle<Value> GetTopRoot(Local<String> property, const AccessorInfo& info);
-  static Handle<Value> GetBottomRoot(Local<String> property, const AccessorInfo& info);
-  static Handle<Value> Delete(const Arguments& args);
+  static NAN_PROPERTY_GETTER(GetUid);
+  static NAN_PROPERTY_GETTER(GetTitle);
+  static NAN_PROPERTY_GETTER(GetTopRoot);
+  static NAN_PROPERTY_GETTER(GetBottomRoot);
+  static NAN_METHOD(Delete);
   static void Initialize();
   static Persistent<ObjectTemplate> profile_template_;
 };

--- a/src/profile_node.cc
+++ b/src/profile_node.cc
@@ -13,11 +13,13 @@ void ProfileNode::Initialize() {
   node_template->SetAccessor(NanNew<String>("functionName"), ProfileNode::GetFunctionName);
   node_template->SetAccessor(NanNew<String>("scriptName"), ProfileNode::GetScriptName);
   node_template->SetAccessor(NanNew<String>("lineNumber"), ProfileNode::GetLineNumber);
+#if (NODE_MODULE_VERSION < 12)
   node_template->SetAccessor(NanNew<String>("totalTime"), ProfileNode::GetTotalTime);
   node_template->SetAccessor(NanNew<String>("selfTime"), ProfileNode::GetSelfTime);
   node_template->SetAccessor(NanNew<String>("totalSamplesCount"), ProfileNode::GetTotalSamplesCount);
   node_template->SetAccessor(NanNew<String>("selfSamplesCount"), ProfileNode::GetSelfSamplesCount);
   node_template->SetAccessor(NanNew<String>("callUid"), ProfileNode::GetCallUid);
+#endif // (NODE_MODULE_VERSION < 12)
   node_template->SetAccessor(NanNew<String>("childrenCount"), ProfileNode::GetChildrenCount);
   node_template->Set(NanNew<String>("getChild"), NanNew<FunctionTemplate>(ProfileNode::GetChild));
 }
@@ -46,6 +48,7 @@ NAN_PROPERTY_GETTER(ProfileNode::GetLineNumber) {
   NanReturnValue(NanNew<Integer>(ln));
 }
 
+#if (NODE_MODULE_VERSION < 12)
 NAN_PROPERTY_GETTER(ProfileNode::GetTotalTime) {
   NanScope();
   Local<Object> self = args.Holder();
@@ -85,6 +88,7 @@ NAN_PROPERTY_GETTER(ProfileNode::GetCallUid) {
   uint32_t uid = static_cast<CpuProfileNode*>(ptr)->GetCallUid();
   NanReturnValue(NanNew<Integer>(uid));
 }
+#endif // (NODE_MODULE_VERSION < 12)
 
 NAN_PROPERTY_GETTER(ProfileNode::GetChildrenCount) {
   NanScope();

--- a/src/profile_node.cc
+++ b/src/profile_node.cc
@@ -7,120 +7,122 @@ namespace nodex {
 Persistent<ObjectTemplate> ProfileNode::node_template_;
 
 void ProfileNode::Initialize() {
-  node_template_ = Persistent<ObjectTemplate>::New(ObjectTemplate::New());
-  node_template_->SetInternalFieldCount(1);
-  node_template_->SetAccessor(String::New("functionName"), ProfileNode::GetFunctionName);
-  node_template_->SetAccessor(String::New("scriptName"), ProfileNode::GetScriptName);
-  node_template_->SetAccessor(String::New("lineNumber"), ProfileNode::GetLineNumber);
-  node_template_->SetAccessor(String::New("totalTime"), ProfileNode::GetTotalTime);
-  node_template_->SetAccessor(String::New("selfTime"), ProfileNode::GetSelfTime);
-  node_template_->SetAccessor(String::New("totalSamplesCount"), ProfileNode::GetTotalSamplesCount);
-  node_template_->SetAccessor(String::New("selfSamplesCount"), ProfileNode::GetSelfSamplesCount);
-  node_template_->SetAccessor(String::New("callUid"), ProfileNode::GetCallUid);
-  node_template_->SetAccessor(String::New("childrenCount"), ProfileNode::GetChildrenCount);
-  node_template_->Set(String::New("getChild"), FunctionTemplate::New(ProfileNode::GetChild));
+  Handle<ObjectTemplate> node_template = ObjectTemplate::New();
+  NanAssignPersistent(node_template_, node_template);
+  node_template->SetInternalFieldCount(1);
+  node_template->SetAccessor(NanNew<String>("functionName"), ProfileNode::GetFunctionName);
+  node_template->SetAccessor(NanNew<String>("scriptName"), ProfileNode::GetScriptName);
+  node_template->SetAccessor(NanNew<String>("lineNumber"), ProfileNode::GetLineNumber);
+  node_template->SetAccessor(NanNew<String>("totalTime"), ProfileNode::GetTotalTime);
+  node_template->SetAccessor(NanNew<String>("selfTime"), ProfileNode::GetSelfTime);
+  node_template->SetAccessor(NanNew<String>("totalSamplesCount"), ProfileNode::GetTotalSamplesCount);
+  node_template->SetAccessor(NanNew<String>("selfSamplesCount"), ProfileNode::GetSelfSamplesCount);
+  node_template->SetAccessor(NanNew<String>("callUid"), ProfileNode::GetCallUid);
+  node_template->SetAccessor(NanNew<String>("childrenCount"), ProfileNode::GetChildrenCount);
+  node_template->Set(NanNew<String>("getChild"), NanNew<FunctionTemplate>(ProfileNode::GetChild));
 }
 
-Handle<Value> ProfileNode::GetFunctionName(Local<String> property, const AccessorInfo& info) {
-  HandleScope scope;
-  Local<Object> self = info.Holder();
-  void* ptr = self->GetPointerFromInternalField(0);
+NAN_PROPERTY_GETTER(ProfileNode::GetFunctionName) {
+  NanScope();
+  Local<Object> self = args.Holder();
+  void* ptr = NanGetInternalFieldPointer(self, 0);
   Handle<String> fname = static_cast<CpuProfileNode*>(ptr)->GetFunctionName();
-  return scope.Close(fname);
+  NanReturnValue(fname);
 }
 
-Handle<Value> ProfileNode::GetScriptName(Local<String> property, const AccessorInfo& info) {
-  HandleScope scope;
-  Local<Object> self = info.Holder();
-  void* ptr = self->GetPointerFromInternalField(0);
+NAN_PROPERTY_GETTER(ProfileNode::GetScriptName) {
+  NanScope();
+  Local<Object> self = args.Holder();
+  void* ptr = NanGetInternalFieldPointer(self, 0);
   Handle<String> sname = static_cast<CpuProfileNode*>(ptr)->GetScriptResourceName();
-  return scope.Close(sname);
+  NanReturnValue(sname);
 }
 
-Handle<Value> ProfileNode::GetLineNumber(Local<String> property, const AccessorInfo& info) {
-  HandleScope scope;
-  Local<Object> self = info.Holder();
-  void* ptr = self->GetPointerFromInternalField(0);
+NAN_PROPERTY_GETTER(ProfileNode::GetLineNumber) {
+  NanScope();
+  Local<Object> self = args.Holder();
+  void* ptr = NanGetInternalFieldPointer(self, 0);
   int32_t ln = static_cast<CpuProfileNode*>(ptr)->GetLineNumber();
-  return scope.Close(Integer::New(ln));
+  NanReturnValue(NanNew<Integer>(ln));
 }
 
-Handle<Value> ProfileNode::GetTotalTime(Local<String> property, const AccessorInfo& info) {
-  HandleScope scope;
-  Local<Object> self = info.Holder();
-  void* ptr = self->GetPointerFromInternalField(0);
+NAN_PROPERTY_GETTER(ProfileNode::GetTotalTime) {
+  NanScope();
+  Local<Object> self = args.Holder();
+  void* ptr = NanGetInternalFieldPointer(self, 0);
   double ttime = static_cast<CpuProfileNode*>(ptr)->GetTotalTime();
-  return scope.Close(Number::New(ttime));
+  NanReturnValue(NanNew<Number>(ttime));
 }
 
-Handle<Value> ProfileNode::GetSelfTime(Local<String> property, const AccessorInfo& info) {
-  HandleScope scope;
-  Local<Object> self = info.Holder();
-  void* ptr = self->GetPointerFromInternalField(0);
+NAN_PROPERTY_GETTER(ProfileNode::GetSelfTime) {
+  NanScope();
+  Local<Object> self = args.Holder();
+  void* ptr = NanGetInternalFieldPointer(self, 0);
   double stime = static_cast<CpuProfileNode*>(ptr)->GetSelfTime();
-  return scope.Close(Number::New(stime));
+  NanReturnValue(NanNew<Number>(stime));
 }
 
-Handle<Value> ProfileNode::GetTotalSamplesCount(Local<String> property, const AccessorInfo& info) {
-  HandleScope scope;
-  Local<Object> self = info.Holder();
-  void* ptr = self->GetPointerFromInternalField(0);
+NAN_PROPERTY_GETTER(ProfileNode::GetTotalSamplesCount) {
+  NanScope();
+  Local<Object> self = args.Holder();
+  void* ptr = NanGetInternalFieldPointer(self, 0);
   double samples = static_cast<CpuProfileNode*>(ptr)->GetTotalSamplesCount();
-  return scope.Close(Number::New(samples));
+  NanReturnValue(NanNew<Number>(samples));
 }
 
-Handle<Value> ProfileNode::GetSelfSamplesCount(Local<String> property, const AccessorInfo& info) {
-  HandleScope scope;
-  Local<Object> self = info.Holder();
-  void* ptr = self->GetPointerFromInternalField(0);
+NAN_PROPERTY_GETTER(ProfileNode::GetSelfSamplesCount) {
+  NanScope();
+  Local<Object> self = args.Holder();
+  void* ptr = NanGetInternalFieldPointer(self, 0);
   double samples = static_cast<CpuProfileNode*>(ptr)->GetSelfSamplesCount();
-  return scope.Close(Number::New(samples));
+  NanReturnValue(NanNew<Number>(samples));
 }
 
-Handle<Value> ProfileNode::GetCallUid(Local<String> property, const AccessorInfo& info) {
-  HandleScope scope;
-  Local<Object> self = info.Holder();
-  void* ptr = self->GetPointerFromInternalField(0);
+NAN_PROPERTY_GETTER(ProfileNode::GetCallUid) {
+  NanScope();
+  Local<Object> self = args.Holder();
+  void* ptr = NanGetInternalFieldPointer(self, 0);
   uint32_t uid = static_cast<CpuProfileNode*>(ptr)->GetCallUid();
-  return scope.Close(Integer::NewFromUnsigned(uid));
+  NanReturnValue(NanNew<Integer>(uid));
 }
 
-Handle<Value> ProfileNode::GetChildrenCount(Local<String> property, const AccessorInfo& info) {
-  HandleScope scope;
-  Local<Object> self = info.Holder();
-  void* ptr = self->GetPointerFromInternalField(0);
+NAN_PROPERTY_GETTER(ProfileNode::GetChildrenCount) {
+  NanScope();
+  Local<Object> self = args.Holder();
+  void* ptr = NanGetInternalFieldPointer(self, 0);
   int32_t count = static_cast<CpuProfileNode*>(ptr)->GetChildrenCount();
-  return scope.Close(Integer::New(count));
+  NanReturnValue(NanNew<Integer>(count));
 }
 
-Handle<Value> ProfileNode::GetChild(const Arguments& args) {
-  HandleScope scope;
+NAN_METHOD(ProfileNode::GetChild) {
+  NanScope();
   if (args.Length() < 1) {
-    return ThrowException(Exception::Error(String::New("No index specified")));
+    NanThrowError("No index specified");
   } else if (!args[0]->IsInt32()) {
-    return ThrowException(Exception::Error(String::New("Argument must be integer")));
+    NanThrowError("Argument must be integer");
   }
   int32_t index = args[0]->Int32Value();
   Handle<Object> self = args.This();
-  void* ptr = self->GetPointerFromInternalField(0);
+  void* ptr = NanGetInternalFieldPointer(self, 0);
   const CpuProfileNode* node = static_cast<CpuProfileNode*>(ptr)->GetChild(index);
-  return scope.Close(ProfileNode::New(node));
+  NanReturnValue(ProfileNode::New(node));
 }
 
 Handle<Value> ProfileNode::New(const CpuProfileNode* node) {
-  HandleScope scope;
-  
+  NanEscapableScope();
+
   if (node_template_.IsEmpty()) {
     ProfileNode::Initialize();
   }
-  
+
   if(!node) {
-    return Undefined();
+    return NanUndefined();
   }
   else {
-    Local<Object> obj = node_template_->NewInstance();
-    obj->SetPointerInInternalField(0, const_cast<CpuProfileNode*>(node));
-    return scope.Close(obj);
+    Local<Object> obj = NanNew<ObjectTemplate>(node_template_)->NewInstance();
+    NanSetInternalFieldPointer(obj, 0, const_cast<CpuProfileNode*>(node));
+    return NanEscapeScope(obj);
   }
 }
-}
+
+} // namespace nodex

--- a/src/profile_node.cc
+++ b/src/profile_node.cc
@@ -19,6 +19,16 @@ void ProfileNode::Initialize() {
   node_template->SetAccessor(NanNew<String>("totalSamplesCount"), ProfileNode::GetTotalSamplesCount);
   node_template->SetAccessor(NanNew<String>("selfSamplesCount"), ProfileNode::GetSelfSamplesCount);
   node_template->SetAccessor(NanNew<String>("callUid"), ProfileNode::GetCallUid);
+#else // (NODE_MODULE_VERSION >= 12)
+  // New in CpuProfileNode: GetHitCount, GetScriptId, GetColumnNumber, GetBailoutReason, GetNodeId.
+  // GetHitCount replaces GetSelfSamplesCount.
+  // Nothing on CpuProfileNode looks like a replacement for GetSelfTime, but the CpuProfile
+  // object has GetSamplesCount, GetSample, GetSampleTimestamp, which might be good for something?
+  // (Nothing replaces GetTotalSamplesCount and GetTotalTime, because bottom-up profiling is gone.)
+  //
+  // GetScriptId, GetBailoutReason, GetColumnNumber seem straightforward but not important.
+  // I don't know what GetNodeId is used for.
+  node_template->SetAccessor(NanNew<String>("hitCount"), ProfileNode::GetHitCount);
 #endif // (NODE_MODULE_VERSION < 12)
   node_template->SetAccessor(NanNew<String>("childrenCount"), ProfileNode::GetChildrenCount);
   node_template->Set(NanNew<String>("getChild"), NanNew<FunctionTemplate>(ProfileNode::GetChild));
@@ -49,6 +59,7 @@ NAN_PROPERTY_GETTER(ProfileNode::GetLineNumber) {
 }
 
 #if (NODE_MODULE_VERSION < 12)
+
 NAN_PROPERTY_GETTER(ProfileNode::GetTotalTime) {
   NanScope();
   Local<Object> self = args.Holder();
@@ -88,6 +99,18 @@ NAN_PROPERTY_GETTER(ProfileNode::GetCallUid) {
   uint32_t uid = static_cast<CpuProfileNode*>(ptr)->GetCallUid();
   NanReturnValue(NanNew<Integer>(uid));
 }
+
+#else // (NODE_MODULE_VERSION >= 12)
+
+NAN_PROPERTY_GETTER(ProfileNode::GetHitCount) {
+  NanScope();
+  Local<Object> self = args.Holder();
+  void* ptr = NanGetInternalFieldPointer(self, 0);
+  uint32_t hitCount = static_cast<CpuProfileNode*>(ptr)->GetHitCount();
+  printf("HitCount %u\n", hitCount);
+  NanReturnValue(NanNew<Integer>(hitCount));
+}
+
 #endif // (NODE_MODULE_VERSION < 12)
 
 NAN_PROPERTY_GETTER(ProfileNode::GetChildrenCount) {
@@ -119,7 +142,7 @@ Handle<Value> ProfileNode::New(const CpuProfileNode* node) {
     ProfileNode::Initialize();
   }
 
-  if(!node) {
+  if (!node) {
     return NanUndefined();
   }
   else {

--- a/src/profile_node.h
+++ b/src/profile_node.h
@@ -19,11 +19,15 @@ class ProfileNode {
    static NAN_PROPERTY_GETTER(GetFunctionName);
    static NAN_PROPERTY_GETTER(GetScriptName);
    static NAN_PROPERTY_GETTER(GetLineNumber);
+#if (NODE_MODULE_VERSION < 12)
    static NAN_PROPERTY_GETTER(GetTotalTime);
    static NAN_PROPERTY_GETTER(GetSelfTime);
    static NAN_PROPERTY_GETTER(GetTotalSamplesCount);
    static NAN_PROPERTY_GETTER(GetSelfSamplesCount);
    static NAN_PROPERTY_GETTER(GetCallUid);
+#else
+   static NAN_PROPERTY_GETTER(GetHitCount);
+#endif
    static NAN_PROPERTY_GETTER(GetChildrenCount);
    static NAN_METHOD(GetChild);
 

--- a/src/profile_node.h
+++ b/src/profile_node.h
@@ -5,6 +5,7 @@
 
 #include <node.h>
 #include <v8-profiler.h>
+#include <nan.h>
 
 using namespace v8;
 
@@ -15,16 +16,17 @@ class ProfileNode {
    static Handle<Value> New(const CpuProfileNode* node);
 
  private:
-   static Handle<Value> GetFunctionName(Local<String> property, const AccessorInfo& info);
-   static Handle<Value> GetScriptName(Local<String> property, const AccessorInfo& info);
-   static Handle<Value> GetLineNumber(Local<String> property, const AccessorInfo& info);
-   static Handle<Value> GetTotalTime(Local<String> property, const AccessorInfo& info);
-   static Handle<Value> GetSelfTime(Local<String> property, const AccessorInfo& info);
-   static Handle<Value> GetTotalSamplesCount(Local<String> property, const AccessorInfo& info);
-   static Handle<Value> GetSelfSamplesCount(Local<String> property, const AccessorInfo& info);
-   static Handle<Value> GetCallUid(Local<String> property, const AccessorInfo& info);
-   static Handle<Value> GetChildrenCount(Local<String> property, const AccessorInfo& info);
-   static Handle<Value> GetChild(const Arguments& args);
+   static NAN_PROPERTY_GETTER(GetFunctionName);
+   static NAN_PROPERTY_GETTER(GetScriptName);
+   static NAN_PROPERTY_GETTER(GetLineNumber);
+   static NAN_PROPERTY_GETTER(GetTotalTime);
+   static NAN_PROPERTY_GETTER(GetSelfTime);
+   static NAN_PROPERTY_GETTER(GetTotalSamplesCount);
+   static NAN_PROPERTY_GETTER(GetSelfSamplesCount);
+   static NAN_PROPERTY_GETTER(GetCallUid);
+   static NAN_PROPERTY_GETTER(GetChildrenCount);
+   static NAN_METHOD(GetChild);
+
    static void Initialize();
    static Persistent<ObjectTemplate> node_template_;
 };

--- a/src/profiler.cc
+++ b/src/profiler.cc
@@ -3,7 +3,7 @@
 
 namespace nodex {
   void InitializeProfiler(Handle<Object> target) {
-    HandleScope scope;
+    NanScope();
     HeapProfiler::Initialize(target);
     CpuProfiler::Initialize(target);
   }

--- a/src/snapshot.cc
+++ b/src/snapshot.cc
@@ -10,101 +10,100 @@ namespace nodex {
 Persistent<ObjectTemplate> Snapshot::snapshot_template_;
 
 void Snapshot::Initialize() {
-  snapshot_template_ = Persistent<ObjectTemplate>::New(ObjectTemplate::New());
-  snapshot_template_->SetInternalFieldCount(1);
-  snapshot_template_->SetAccessor(String::New("title"), Snapshot::GetTitle);
-  snapshot_template_->SetAccessor(String::New("uid"), Snapshot::GetUid);
-  snapshot_template_->SetAccessor(String::New("type"), Snapshot::GetType);
-  snapshot_template_->Set(String::New("delete"), FunctionTemplate::New(Snapshot::Delete));
-  snapshot_template_->Set(String::New("serialize"), FunctionTemplate::New(Snapshot::Serialize));
+  Handle<ObjectTemplate> snapshot_template = ObjectTemplate::New();
+  NanAssignPersistent(snapshot_template_, snapshot_template);
+  snapshot_template->SetInternalFieldCount(1);
+  snapshot_template->SetAccessor(NanNew<String>("title"), Snapshot::GetTitle);
+  snapshot_template->SetAccessor(NanNew<String>("uid"), Snapshot::GetUid);
+  snapshot_template->SetAccessor(NanNew<String>("type"), Snapshot::GetType);
+  snapshot_template->Set(NanNew<String>("delete"), NanNew<FunctionTemplate>(Snapshot::Delete));
+  snapshot_template->Set(NanNew<String>("serialize"), NanNew<FunctionTemplate>(Snapshot::Serialize));
 }
 
-Handle<Value> Snapshot::GetTitle(Local<String> property, const AccessorInfo& info) {
-  HandleScope scope;
-  Local<Object> self = info.Holder();
-  void* ptr = self->GetPointerFromInternalField(0);
+NAN_PROPERTY_GETTER(Snapshot::GetTitle) {
+  NanScope();
+  Local<Object> self = args.Holder();
+  void* ptr = NanGetInternalFieldPointer(self, 0);
   Handle<String> title = static_cast<HeapSnapshot*>(ptr)->GetTitle();
-  return scope.Close(title);
+  NanReturnValue(title);
 }
 
-Handle<Value> Snapshot::GetUid(Local<String> property, const AccessorInfo& info) {
-  HandleScope scope;
-  Local<Object> self = info.Holder();
-  void* ptr = self->GetPointerFromInternalField(0);
+NAN_PROPERTY_GETTER(Snapshot::GetUid) {
+  NanScope();
+  Local<Object> self = args.Holder();
+  void* ptr = NanGetInternalFieldPointer(self, 0);
   uint32_t uid = static_cast<HeapSnapshot*>(ptr)->GetUid();
-  return scope.Close(Integer::NewFromUnsigned(uid));
+  NanReturnValue(NanNew<Integer>(uid));
 }
 
-Handle<Value> Snapshot::GetType(Local<String> property, const AccessorInfo& info) {
-  HandleScope scope;
-  Local<Object> self = info.Holder();
-  void* ptr = self->GetPointerFromInternalField(0);
+NAN_PROPERTY_GETTER(Snapshot::GetType) {
+  NanScope();
+  Local<Object> self = args.Holder();
+  void* ptr = NanGetInternalFieldPointer(self, 0);
 
   HeapSnapshot::Type type = static_cast<HeapSnapshot*>(ptr)->GetType();
   Local<String> t;
 
   switch(type) {
     case HeapSnapshot::kFull:
-      t = String::New("Full");
+      t = NanNew<String>("Full");
       break;
     default:
-      t = String::New("Unknown");
+      t = NanNew<String>("Unknown");
   }
 
-  return scope.Close(t);
+  NanReturnValue(t);
 }
 
-Handle<Value> Snapshot::Delete(const Arguments& args) {
-    HandleScope scope;
+NAN_METHOD(Snapshot::Delete) {
+    NanScope();
     Handle<Object> self = args.This();
-    void* ptr = self->GetPointerFromInternalField(0);
+    void* ptr = NanGetInternalFieldPointer(self, 0);
     static_cast<HeapSnapshot*>(ptr)->Delete();
-    return Undefined();
+    NanReturnUndefined();
 }
 
 Handle<Value> Snapshot::New(const HeapSnapshot* snapshot) {
-  HandleScope scope;
+  NanEscapableScope();
 
   if (snapshot_template_.IsEmpty()) {
     Snapshot::Initialize();
   }
 
   if(!snapshot) {
-    return Undefined();
+    return NanUndefined();
   }
   else {
-    Local<Object> obj = snapshot_template_->NewInstance();
-    obj->SetPointerInInternalField(0, const_cast<HeapSnapshot*>(snapshot));
-    return scope.Close(obj);
+    Local<ObjectTemplate> snapshot_template = NanNew<ObjectTemplate>(snapshot_template_);
+    Local<Object> obj = snapshot_template->NewInstance();
+    NanSetInternalFieldPointer(obj, 0, const_cast<HeapSnapshot*>(snapshot));
+    return NanEscapeScope(obj);
   }
 }
 
 class OutputStreamAdapter : public v8::OutputStream {
   public:
     OutputStreamAdapter(Handle<Value> arg) {
-      Local<String> onEnd = String::New("onEnd");
-      Local<String> onData = String::New("onData");
+      Local<String> onEnd = NanNew<String>("onEnd");
+      Local<String> onData = NanNew<String>("onData");
 
       if (!arg->IsObject()) {
-        ThrowException(Exception::TypeError(
-          String::New("You must specify an Object as first argument")));
+        NanThrowTypeError("You must specify an Object as first argument");
       }
 
       obj = arg->ToObject();
       if (!obj->Has(onEnd) || !obj->Has(onData)) {
-        ThrowException(Exception::TypeError(
-          String::New("You must specify properties 'onData' and 'onEnd' to invoke this function")));
+        NanThrowTypeError("You must specify properties 'onData' and 'onEnd' to invoke this function");
       }
 
       if (!obj->Get(onEnd)->IsFunction() || !obj->Get(onData)->IsFunction()) {
-        ThrowException(Exception::TypeError(
-          String::New("Properties 'onData' and 'onEnd' have to be functions")));
+        NanThrowTypeError("Properties 'onData' and 'onEnd' have to be functions");
       }
 
       onEndFunction = Local<Function>::Cast(obj->Get(onEnd));
       onDataFunction = Local<Function>::Cast(obj->Get(onData));
 
-      abort = Local<Value>::New(Boolean::New(false));
+      abort = NanFalse();
     }
 
     void EndOfStream() {
@@ -121,11 +120,11 @@ class OutputStreamAdapter : public v8::OutputStream {
     }
 
     WriteResult WriteAsciiChunk(char* data, int size) {
-      HandleScope scope;
+      NanScope();
 
       Handle<Value> argv[2] = {
-        Buffer::New(data, size)->handle_,
-        Integer::New(size)
+        NanNewBufferHandle(data, size),
+        NanNew<Integer>(size)
       };
 
       TryCatch try_catch;
@@ -150,23 +149,22 @@ class OutputStreamAdapter : public v8::OutputStream {
     Handle<Function> onDataFunction;
 };
 
-Handle<Value> Snapshot::Serialize(const Arguments& args) {
-  HandleScope scope;
+NAN_METHOD(Snapshot::Serialize) {
+  NanScope();
   Handle<Object> self = args.This();
 
   uint32_t argslen = args.Length();
 
   if (argslen == 0) {
-    return ThrowException(Exception::TypeError(
-      String::New("You must specify arguments to invoke this function")));
+    NanThrowTypeError("You must specify arguments to invoke this function");
   }
 
   OutputStreamAdapter *stream = new OutputStreamAdapter(args[0]);
 
-  void* ptr = self->GetPointerFromInternalField(0);
+  void* ptr = NanGetInternalFieldPointer(self, 0);
   static_cast<HeapSnapshot*>(ptr)->Serialize(stream, HeapSnapshot::kJSON);
 
-  return Undefined();
+  NanReturnUndefined();
 }
 
 } //namespace nodex

--- a/src/snapshot.cc
+++ b/src/snapshot.cc
@@ -15,7 +15,9 @@ void Snapshot::Initialize() {
   snapshot_template->SetInternalFieldCount(1);
   snapshot_template->SetAccessor(NanNew<String>("title"), Snapshot::GetTitle);
   snapshot_template->SetAccessor(NanNew<String>("uid"), Snapshot::GetUid);
+#if (NODE_MODULE_VERSION < 12)
   snapshot_template->SetAccessor(NanNew<String>("type"), Snapshot::GetType);
+#endif // (NODE_MODULE_VERSION < 12)
   snapshot_template->Set(NanNew<String>("delete"), NanNew<FunctionTemplate>(Snapshot::Delete));
   snapshot_template->Set(NanNew<String>("serialize"), NanNew<FunctionTemplate>(Snapshot::Serialize));
 }
@@ -36,6 +38,7 @@ NAN_PROPERTY_GETTER(Snapshot::GetUid) {
   NanReturnValue(NanNew<Integer>(uid));
 }
 
+#if (NODE_MODULE_VERSION < 12)
 NAN_PROPERTY_GETTER(Snapshot::GetType) {
   NanScope();
   Local<Object> self = args.Holder();
@@ -54,6 +57,7 @@ NAN_PROPERTY_GETTER(Snapshot::GetType) {
 
   NanReturnValue(t);
 }
+#endif // (NODE_MODULE_VERSION < 12)
 
 NAN_METHOD(Snapshot::Delete) {
     NanScope();

--- a/src/snapshot.h
+++ b/src/snapshot.h
@@ -5,6 +5,7 @@
 
 #include <node.h>
 #include <v8-profiler.h>
+#include <nan.h>
 
 using namespace v8;
 
@@ -20,18 +21,11 @@ class Snapshot {
 
     const v8::HeapSnapshot* m_snapshot;
 
-    static Handle<Value> GetUid(Local<String> property, const AccessorInfo& info);
-    static Handle<Value> GetTitle(Local<String> property, const AccessorInfo& info);
-    static Handle<Value> GetMaxSnapshotJSObjectId(Local<String> property, const AccessorInfo& info);
-    static Handle<Value> GetRoot(Local<String> property, const AccessorInfo& info);
-    static Handle<Value> GetType(Local<String> property, const AccessorInfo& info);
-    static Handle<Value> GetNodesCount(Local<String> property, const AccessorInfo& info);
-    static Handle<Value> GetNodeById(const Arguments& args);
-    static Handle<Value> GetNode(const Arguments& args);
-    static Handle<Value> Delete(const Arguments& args);
-    static Handle<Value> Serialize(const Arguments& args);
-
-    static Handle<Value> SnapshotObjectId(const Arguments& args);
+    static NAN_PROPERTY_GETTER(GetUid);
+    static NAN_PROPERTY_GETTER(GetTitle);
+    static NAN_PROPERTY_GETTER(GetType);
+    static NAN_METHOD(Delete);
+    static NAN_METHOD(Serialize);
 
     static void Initialize();
     static Persistent<ObjectTemplate> snapshot_template_;


### PR DESCRIPTION
This compiles with node 0.10.33 and seems to work in some cursory
tests.

This comes near to compiling with node 0.12.0, except for a bunch of
errors like

- error: ‘DeleteAllSnapshots’ is not a member of ‘v8::HeapProfiler’

- error: ‘class v8::CpuProfileNode’ has no member named ‘GetSelfTime’

These are changes to the V8 profiler API that are not abstracted by
nan.